### PR TITLE
Handle case where text is null or undefined

### DIFF
--- a/vue-truncate.js
+++ b/vue-truncate.js
@@ -13,6 +13,7 @@
      */
 
     Vue.filter('truncate', function (text, length, clamp) {
+      text = typeof text === 'undefined' || text === null ? '' : text;
       clamp = clamp || '...';
       length = length || 30;
       


### PR DESCRIPTION
Prevents errors like `Cannot read property 'length' of null` by defaulting to an empty string.